### PR TITLE
Quicker spatial queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.cfg.php
+*~

--- a/README.md
+++ b/README.md
@@ -42,14 +42,16 @@ URLs:
 
 # 2. Installatie
 
-De installatie maakt de databasetabellen aan. 
-Voer install.php uit vanuit een opdrachtregel. Als er nog 
+De installatie maakt de databasetabellen aan.
+Voor toegankelijkheid op de HTML-server dient het mapje verkeersbordenkaart
+naar /var/www/html/ gekopieërd te worden.
+Voer setup/install.php uit vanuit een opdrachtregel. Als er nog 
 geen configuratiebestand aanwezig is, wordt dit aangemaakt. Open dit 
 met een teksteditor en vul de juiste databasecredentials is. Voer 
 hierna install.php nogmaals uit om de databasetabellen aan te maken.
 
 Wanneer de installatie gereed is kunnen de tabellen worden gevuld. Voer 
-hiervoor cronjob.php uit. Er gelden timeouts zoals geconfigureerd in
+hiervoor getdata/cronjob.php uit. Er gelden timeouts zoals geconfigureerd in
 config.cfg.php. Afhankelijk van de ingestelde waarden moet cronjob.php
 meermaals worden uitgevoerd om de volledige dataset binnen te halen.
 

--- a/functions/bounds_to_sql.php
+++ b/functions/bounds_to_sql.php
@@ -22,6 +22,7 @@
 /*
 * function to check map's bbox string and convert to sql component
 * $bounds in format (str) southwest_lng,southwest_lat,northeast_lng,northeast_lat
+* Update 2021/03/08: make that a box (MBR) for speedy queries using spatial index
 */
 function bounds_to_sql($bounds) {
 	$bounds = explode(',', $bounds);
@@ -35,8 +36,8 @@ function bounds_to_sql($bounds) {
 	$lon_lower = min($bounds[0], $bounds[2]);
 	$lon_upper = max($bounds[0], $bounds[2]);
 	
-	//added location.wgs84. to field names
-	return ' `location.wgs84.latitude` BETWEEN '. $lat_lower . ' AND '. $lat_upper . ' 
-	AND `location.wgs84.longitude` BETWEEN '. $lon_lower . ' AND '. $lon_upper . ' ';
+	return ' MBRContains(GeomFromText( "LINESTRING(' . 
+           $lat_lower . ' ' . $lon_lower . ', ' . 
+	   $lat_upper . ' ' . $lon_upper . ')"), `wgs84`) ';
 }
 ?>

--- a/getdata/cronjob.php
+++ b/getdata/cronjob.php
@@ -66,7 +66,6 @@ function curl_get_contents($url, $verifyPeer) {
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
 	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $verifyPeer);
-	//curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
 	curl_setopt($ch, CURLOPT_URL, $url);
 	$contents = curl_exec($ch);
 	if ($contents === FALSE) {
@@ -137,9 +136,22 @@ while(TRUE) {
 			//var_dump($item); exit;
 			//TODO check data contents
 
+			// Data to be sanitized (my PHP appears to be fussy)
+			if ($item->validated == 'n') 
+			   $item->validated=0;
+			else 
+			   $item->validated=1;
+			if ($item->user_id=='') $item->user_id=0;
+			if ($item->organisation_id=='') $item->organisation_id=0;
+			if ($item->location->road->wvk_id=='') $item->location->road->wvk_id=0;
+			if ($item->location->road->type=='') $item->location->road->type=0;			
+			if ($item->location->road->number=='') $item->location->road->number=0;			    // And here's to (my) MySQL not accepting ISO8601 dates:
+			$item->publication_timestamp_output=date_format(date_create($item->publication_timestamp), "Y-m-d H:i:s.v");
+
+
 			$contents = "`type` = '" . mysqli_real_escape_string($db['link'], $item->type) . "',
 			`schema_version` = '" . mysqli_real_escape_string($db['link'], $item->schema_version) . "',
-			`publication_timestamp` = '" . mysqli_real_escape_string($db['link'], $item->publication_timestamp) . "',
+			`publication_timestamp` = '" . mysqli_real_escape_string($db['link'], $item->publication_timestamp_output) . "',
 			`validated` = '" . mysqli_real_escape_string($db['link'], $item->validated) . "',
 			`validated_on` = " . date_to_db($item->validated_on) . ",
 			`user_id` = '" . mysqli_real_escape_string($db['link'], $item->user_id) . "',
@@ -169,7 +181,10 @@ while(TRUE) {
 				. $contents . 
 				" ON DUPLICATE KEY UPDATE "
 				. $contents;
-			mysqli_query($db['link'], $qry);
+			if (! mysqli_query($db['link'], $qry) ) {
+			   echo mysqli_error($db['link']), "\n";
+			   print "$qry\n\n";
+			}
 
 			//laatste publication_timestamp
 			if (preg_match('#\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z#', $item->publication_timestamp)) {

--- a/getdata/cronjob.php
+++ b/getdata/cronjob.php
@@ -58,14 +58,15 @@ else {
 	}
 }
 
-function curl_get_contents($url) {
+function curl_get_contents($url, $verifyPeer) {
 	$error = 0;
 	$ch = curl_init();
 	curl_setopt($ch, CURLOPT_AUTOREFERER, TRUE);
 	curl_setopt($ch, CURLOPT_HEADER, FALSE);
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 	curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
-	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $cfg_resource['CURLOPT_SSL_VERIFYPEER']);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, $verifyPeer);
+	//curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, TRUE);
 	curl_setopt($ch, CURLOPT_URL, $url);
 	$contents = curl_exec($ch);
 	if ($contents === FALSE) {
@@ -98,10 +99,11 @@ while(TRUE) {
 
 	//haal data van API
 	$url = $cfg_resource['API'];
+	$verifyPeer = $cfg_resource['CURLOPT_SSL_VERIFYPEER'];
 	if (!empty($updatestate)) {
 		$url .= '?offset=' . $updatestate['offset'];
 	}
-	$data = curl_get_contents($url);
+	$data = curl_get_contents($url, $verifyPeer);
 
 	//verwerk api error
 	if ($data[0] == 1) {

--- a/getdata/cronjob.php
+++ b/getdata/cronjob.php
@@ -151,6 +151,8 @@ while(TRUE) {
 			// text_signs is MYSQL TINYTEXT, max 255 characters. Crop any excess characters to avoid error:
 			$text255 = substr(json_encode($item->text_signs),1,-1); # strip starting and trailing "
 			$text255 = '"' . substr($text255,0,253) . '"';
+			// location.side is sometimes 'bord.schouw onbekend', setting to 'X' (one-char limit)
+			if (strlen( $item->location->side ) > 1) $item->location->side='X';
 
 			$contents = "`type` = '" . mysqli_real_escape_string($db['link'], $item->type) . "',
 			`schema_version` = '" . mysqli_real_escape_string($db['link'], $item->schema_version) . "',

--- a/getdata/cronjob.php
+++ b/getdata/cronjob.php
@@ -160,6 +160,8 @@ while(TRUE) {
 			`text_signs` = '" . mysqli_real_escape_string($db['link'], json_encode($item->text_signs)) . "',
 			`location.wgs84.latitude` = '" . mysqli_real_escape_string($db['link'], $item->location->wgs84->latitude) . "',
 			`location.wgs84.longitude` = '" . mysqli_real_escape_string($db['link'], $item->location->wgs84->longitude) . "',
+			`wgs84` = geomfromtext('Point(" . mysqli_real_escape_string($db['link'], $item->location->wgs84->latitude) .
+			                            " " . mysqli_real_escape_string($db['link'], $item->location->wgs84->longitude) . ")'),
 			`location.rd.x` = '" . mysqli_real_escape_string($db['link'], $item->location->rd->x) . "',
 			`location.rd.y` = '" . mysqli_real_escape_string($db['link'], $item->location->rd->y) . "',
 			`location.placement` = '" . mysqli_real_escape_string($db['link'], $item->location->placement) . "',

--- a/getdata/cronjob.php
+++ b/getdata/cronjob.php
@@ -145,9 +145,12 @@ while(TRUE) {
 			if ($item->organisation_id=='') $item->organisation_id=0;
 			if ($item->location->road->wvk_id=='') $item->location->road->wvk_id=0;
 			if ($item->location->road->type=='') $item->location->road->type=0;			
-			if ($item->location->road->number=='') $item->location->road->number=0;			    // And here's to (my) MySQL not accepting ISO8601 dates:
+			if ($item->location->road->number=='') $item->location->road->number=0;
+			// And here's to (my) MySQL not accepting ISO8601 dates:
 			$item->publication_timestamp_output=date_format(date_create($item->publication_timestamp), "Y-m-d H:i:s.v");
-
+			// text_signs is MYSQL TINYTEXT, max 255 characters. Crop any excess characters to avoid error:
+			$text255 = substr(json_encode($item->text_signs),1,-1); # strip starting and trailing "
+			$text255 = '"' . substr($text255,0,253) . '"';
 
 			$contents = "`type` = '" . mysqli_real_escape_string($db['link'], $item->type) . "',
 			`schema_version` = '" . mysqli_real_escape_string($db['link'], $item->schema_version) . "',
@@ -157,7 +160,7 @@ while(TRUE) {
 			`user_id` = '" . mysqli_real_escape_string($db['link'], $item->user_id) . "',
 			`organisation_id` = '" . mysqli_real_escape_string($db['link'], $item->organisation_id) . "',
 			`rvv_code` = '" . mysqli_real_escape_string($db['link'], $item->rvv_code) . "',
-			`text_signs` = '" . mysqli_real_escape_string($db['link'], json_encode($item->text_signs)) . "',
+			`text_signs` = '" . mysqli_real_escape_string($db['link'], $text255) . "',
 			`location.wgs84.latitude` = '" . mysqli_real_escape_string($db['link'], $item->location->wgs84->latitude) . "',
 			`location.wgs84.longitude` = '" . mysqli_real_escape_string($db['link'], $item->location->wgs84->longitude) . "',
 			`wgs84` = geomfromtext('Point(" . mysqli_real_escape_string($db['link'], $item->location->wgs84->latitude) .

--- a/help/about.php
+++ b/help/about.php
@@ -17,7 +17,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-include('dbconnect.inc.php');
+include('../dbconnect.inc.php');
 
 $qry = "SELECT * FROM `updatelog` ORDER BY `id` DESC LIMIT 1";
 $res = mysqli_query($db['link'], $qry);

--- a/setup/addindex.php
+++ b/setup/addindex.php
@@ -1,0 +1,18 @@
+<?php
+
+// add spatial index (along with matching 'point' column) to database created in install.php
+
+
+include('../dbconnect.inc.php'); // so script can be run independently from install.php
+// Add spatial column
+$qry = "alter table `verkeersborden` add `wgs84` point not null;";
+$res = mysqli_query($db['link'], $qry);
+// populate
+$qry = "update `verkeersborden` set `wgs84` = Point (`location.wgs84.latitude`, `location.wgs84.longitude`);";
+$res = mysqli_query($db['link'], $qry);
+//create spatial index
+$qry = "alter table `verkeersborden` add spatial index(`wgs84`);";
+$res = mysqli_query($db['link'], $qry);
+
+
+?>

--- a/setup/install.php
+++ b/setup/install.php
@@ -95,6 +95,7 @@ else {
 	else echo 'did not create table `verkeersborden`'.PHP_EOL;
 	echo mysqli_error($db['link']).PHP_EOL;
 
+	include('addindex.php');
 
 	$qry = "CREATE TABLE IF NOT EXISTS `updatelog`
 	(


### PR DESCRIPTION
This PR speeds up spatial queries (e.g., when loading or moving the map) by orders of magnitude.  Previously, each query did a sequential search of the entire database.  With ~2M rows, this took ~10s on my machine, each time, degrading the user experience. I've changed the scripts to initialize, populate, and search the database such that a spatial index is used for the query. Queries are now near-instantaneous, and I can quickly pan and zoom around.  It also reduces server load, I guess.
It's possible to upgrade your existing database without re-downloading all data from NDW, just run setup/addindex.php.

This PR is independent of my earlier PR (although the other PR's commits are contained herein, they're not needed for this to work).

PS: sorry for writing in English, and please feel free to reply in Dutch.  I'm in a videocall in English (waiting for my topic of interest to come up), and my brain can't do two languages at the same time.